### PR TITLE
Fix Poetry install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  pull_request:
+  push:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: poetry
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install --with dev --no-root
+      - name: Run tests
+        run: poetry run pytest


### PR DESCRIPTION
## Summary
- add a CI workflow installing dependencies without the root package

## Testing
- `pytest` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_6865a5614a00832b8a068daaf306b6b8