### PR TITLE
Fix CI workflow by removing poetry cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-          cache: poetry
       - name: Install dependencies
         run: |
           pip install poetry


### PR DESCRIPTION
## Summary
- remove unsupported poetry cache from CI setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865a7653db0832bbf1f7209a7cbf5b5