### PR TITLE
Add minimal health endpoint test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ black = "*"
 isort = "*"
 pytest = "*"
 pytest-asyncio = "*"
+httpx = "<0.27"
 pre-commit = "*"
 detect-secrets = "*"
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+def test_root_health() -> None:
+    """Vérifie que la route racine répond 200 et le JSON attendu."""
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello world"}


### PR DESCRIPTION
## Summary
- add tests for root endpoint
- pin httpx below 0.27 for compatibility with Starlette's TestClient

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68691b4ed1ac832ba230cb3e2190c11e