### PR TITLE
Remove unused variable from roadmap update script

### DIFF
--- a/scripts/update_roadmap.py
+++ b/scripts/update_roadmap.py
@@ -16,14 +16,12 @@ def main():
 
     updated_lines = []
     for line in lines:
-        updated = False
         for tag in tags:
             pattern = rf'^- \[ \] <!--TASK:{re.escape(tag)}-->(.*)$'
             m = re.match(pattern, line)
             if m:
                 desc = m.group(1).strip()
                 line = f"- [x] <!--TASK:{tag}-->~~{desc}~~\n"
-                updated = True
                 break
         updated_lines.append(line)
 


### PR DESCRIPTION
## Summary
- clean up `scripts/update_roadmap.py` by dropping the unused `updated` variable

## Testing
- `ruff check scripts/update_roadmap.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b163c8ca0832b87074e492b7a7034