### PR TITLE
Add basic FastAPI health check and placeholder tests

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+def test_health() -> None:
+    """Vérifie que la racine répond correctement."""
+    r = client.get("/")
+    assert r.status_code == 200
+    assert r.json() in ({"message": "Hello world"}, {"status": "ok"})

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,3 @@
+def test_placeholder() -> None:
+    """Test toujours vrai pour éviter 'no tests ran' si on déplace d’autres tests."""
+    assert True


### PR DESCRIPTION
## Summary
- add a simple FastAPI health endpoint test
- add a placeholder test to ensure at least one test is always collected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b1f39fd14832b93562378d45d64a9