### PR TITLE
Move httpx to main dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ uvicorn = {extras = ["standard"], version = "*"}
 pydantic = "*"
 opencv-python = "*"
 ultralytics = "*"
+httpx = "^0.27.2"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary
- move httpx from dev group to main dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b20e40a78832bbf6bf7ab697a8bfb