### PR TITLE
Add simple FastAPI API and tests

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from backend.database import SessionLocal
+from backend.database.models import Game, Event, StatsSnapshot
+from backend.database.schemas import GameOut, EventIn, StatsOut
+
+router = APIRouter()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("/games", response_model=list[GameOut])
+def list_games(db: Session = Depends(get_db)):
+    return db.query(Game).all()
+
+
+@router.get("/games/{game_id}", response_model=GameOut)
+def get_game(game_id: int, db: Session = Depends(get_db)):
+    game = db.get(Game, game_id)
+    if not game:
+        raise HTTPException(status_code=404, detail="Game not found")
+    return game
+
+
+@router.post("/events", status_code=201)
+def create_event(event: EventIn, db: Session = Depends(get_db)):
+    db_event = Event(**event.dict())
+    db.add(db_event)
+    db.commit()
+    db.refresh(db_event)
+    return {"id": db_event.id}
+
+
+@router.get("/stats/{game_id}", response_model=list[StatsOut])
+def get_stats(game_id: int, db: Session = Depends(get_db)):
+    return db.query(StatsSnapshot).filter(StatsSnapshot.game_id == game_id).all()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,11 @@
 from fastapi import FastAPI
 
+from .api import router
+
 app = FastAPI()
 
 @app.get("/")
 async def read_root():
     return {"message": "Hello world"}
+
+app.include_router(router)

--- a/backend/database/schemas.py
+++ b/backend/database/schemas.py
@@ -49,3 +49,31 @@ class StatsSnapshotSchema(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+# Additional schemas used for the API
+class GameOut(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True
+
+
+class EventIn(BaseModel):
+    type: str
+    timestamp: datetime | None = None
+    game_id: int
+    player_id: int | None = None
+    team_id: int | None = None
+
+
+class StatsOut(BaseModel):
+    id: int
+    data: str | None = None
+    game_id: int
+    player_id: int | None = None
+    team_id: int | None = None
+
+    class Config:
+        orm_mode = True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,52 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.app.main import app
+from backend.app import api as api_module
+from backend.database.models import Base, Game, Team, Player
+
+
+# Setup in-memory database for testing
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+    future=True,
+)
+TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[api_module.get_db] = override_get_db
+client = TestClient(app)
+
+
+# Insert initial data
+with TestingSessionLocal() as session:
+    game = Game(name="Test Game")
+    team = Team(name="Team A", game=game)
+    player = Player(name="Player 1", team=team)
+    session.add_all([game, team, player])
+    session.commit()
+
+
+def test_get_games():
+    response = client.get("/games")
+    assert response.status_code == 200
+    assert response.json() == [{"id": 1, "name": "Test Game"}]
+
+
+def test_post_events():
+    data = {"type": "score", "game_id": 1}
+    response = client.post("/events", json=data)
+    assert response.status_code == 201


### PR DESCRIPTION
## Summary
- implement new `api.py` router with basic CRUD endpoints
- register the API router in `main.py`
- add API-specific Pydantic models in `schemas.py`
- create tests for API endpoints using TestClient

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b8ede0a84832bbde7034238bbf6bc